### PR TITLE
Handling multiple tag lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Example Values: ```100``` or ```400```
 Specify an element that, when clicked, will return the sorted elements to their initial state by resetting all tags. No default element is used.
 
 Example Values: ```.tagsort-reset``` or ```#button-tags-reset```
+===
+**`tagAttr` (Optional, default: `data-item-tags`)**
+
+Specify the attribute name that is used to retrieve the list of tags on each element. This allows to have several filters on the same set of elements.
+
+Example Values: ```data-item-tags```
 
 
 ###Todo

--- a/tagsort.js
+++ b/tagsort.js
@@ -1,5 +1,4 @@
 ;(function($) {
-  var tagSortEngine;
   $.fn.tagSort = function(options) {
     // Default options
     var defaults = {
@@ -14,12 +13,13 @@
       fadeTime: 0,
       sortAlphabetical: false,
       reset: false,
+      tagAttr: 'data-item-tags',
       getElement: function(element){ return element; },
     };
     // Overwrite defaults with any user-supplied options
 
     // Namespace
-    tagSortEngine = {
+    var tagSortEngine = {
       generateTags: function() {
         var tags_inclusive = {},
             tags_exclusive = {pointers: [], tags: []},
@@ -29,7 +29,7 @@
         tagSortEngine.elements.each(function(i) {
           $element = $(this);
           // Pull tags from element data attribute and dump into array
-          var tagsData = $element.attr('data-item-tags')
+          var tagsData = $element.attr(tagSortEngine.options.tagAttr)
           tagsData = (typeof tagsData === 'string' && tagsData !== '') ?  tagsData : 'Untagged';
           var elementTags = tagsData.match(/,\s+/) ? tagsData.split(', ') : tagsData.split(',');
             // Inclusive Filtering only: Loop through each element's tags


### PR DESCRIPTION
This pull request modifies tagsort so it can handle multiple lists. I use it this way

```
$().ready(function() {
    $('div.tagsort-tags-container').each(function() {
        $(this).tagSort({
            items: '.item-to-filter',
            tagAttr: this.getAttribute("tagname") || "data-item-tags"
        });
    });
});
```

In the patch, there are two things:
- new option + documentation
- tagSortEngine becomes a local variable so that there are no conflicts